### PR TITLE
Update ML-dev to requirements from Week0 folder

### DIFF
--- a/docs/ML-dev.yaml
+++ b/docs/ML-dev.yaml
@@ -1,13 +1,25 @@
 name: ML
 channels:
-  - apple
   - conda-forge
+  - pytorch
+  - apple
   - bioconda
+  - defaults
 dependencies:
-  - pip=22.0.4=pyhd8ed1ab_0
-  - python=3.9.0=h4b4120c_5_cpython
-  - scikit-learn=1.0.2=py39hef7049f_0
-  - tensorflow-deps=2.8.0=0
-  - pip:
-    - tensorflow-macos==2.8.0
-    - tensorflow-metal==0.4.0
+  - python=3.12
+  - h5py=3.13.0
+  - ipywidgets=8.1.6
+  - lightgbm=4.6.0
+  - matplotlib=3.10.1
+  - notebook=7.4.0
+  - numpy=2.1.3
+  - pandas=2.2.3
+  - scikit-learn=1.6.1
+  - scipy=1.15.2
+  - seaborn=0.13.2
+  - tensorflow=2.18.0
+  - pytorch=2.6.0
+  - torch-geometric=2.6.1
+  - torchaudio=2.6.0
+  - torchvision=0.21.0
+  - xgboost=3.0.0


### PR DESCRIPTION
I found a `yaml` file describing an Anaconda environment. It's out of date however, so I went to update it.

Works on macOS and can be installed with

```bash
conda env create -n ML -f docs/ML-dev.yaml
```

### Requirements

* Anaconda